### PR TITLE
chore: Install rsync to fix failing build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,6 @@ workflow:
   rules:
     - if: $CI_COMMIT_TAG
 
-
 build-and-release:
   stage: build
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/ruby:$RUBY_VERSION

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,9 +5,13 @@ workflow:
   rules:
     - if: $CI_COMMIT_TAG
 
+
 build-and-release:
   stage: build
   image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/ruby:$RUBY_VERSION
+  before_script:
+    - apt-get update -y
+    - apt-get -y install rsync
   script:
     - bundle install
     - pod trunk push --allow-root


### PR DESCRIPTION
Cocoapods [release build](https://gitlab.com/primer-io/checkout/primer-stripe-sdk-ios/-/jobs/8707800128) is failing due to missing `rsync` on CI. 

This aims to rectify